### PR TITLE
Fix header cutting off main content on various viewport sizes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,7 +62,7 @@ function App() {
   return (
     <div className="relative">
       <NavBar onNavClick={handleNavClick} />
-      <main>
+      <main className="pt-16">
         <motion.div
           id="home"
           className="min-h-screen"

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 
 function Landing() {
   return (
-    <div className="hero min-h-[calc(100vh-65px)] w-full">
+    <div className="hero min-h-[calc(100vh-4rem)] w-full">
       <div className="hero-content flex-col xl:flex-row items-center h-full">
         <motion.div
           className="lg:col-6 lg:p-0 p-6 flex-col col-span-full"

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -80,7 +80,7 @@ function NavBar({ onNavClick }) {
           </svg>
         </button>
         <div
-          className={`fixed top-[65px] right-0 w-48 bg-base-100 shadow-lg transition-all duration-300 ease-in-out ${
+          className={`fixed top-16 right-0 w-48 bg-base-100 shadow-lg transition-all duration-300 ease-in-out ${
             isMenuOpen ? "translate-x-0" : "translate-x-full"
           }`}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -25,5 +25,5 @@ html {
 }
 
 [id] {
-  scroll-margin-top: 3rem; /* Increased to account for navbar height */
+  scroll-margin-top: 5rem; /* Account for fixed navbar height (~4rem) plus buffer */
 }


### PR DESCRIPTION
Add pt-16 to <main> so content starts below the fixed navbar instead of rendering behind it. Normalize hardcoded 65px values to Tailwind's 4rem (top-16) for consistency with DaisyUI's navbar min-height, and increase scroll-margin-top from 3rem to 5rem so anchor-scrolled sections clear the navbar.