### PR TITLE
Refactor portfolio into shared modules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default [
     rules: {
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]|^motion$' }],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,44 +7,17 @@ import LanguageSkills from "./components/LanguageSkills";
 import GitHubStats from "./components/GitHubStats";
 import LeetCodeStats from "./components/LeetCodeStats";
 import Contact from "./components/Contact";
-import { useState, useEffect, useMemo } from "react";
-import { motion } from "framer-motion";
+import SectionWrapper from "./components/SectionWrapper";
+import BackToTopButton from "./components/BackToTopButton";
+import { useMemo } from "react";
 
 const VALID_PASSWORD = "password123";
 
 function App() {
-  const [showBackToTop, setShowBackToTop] = useState(false);
-
   const isAuthenticated = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get("password") === VALID_PASSWORD;
   }, []);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      // Show button when scrolled down more than 300px
-      const shouldShow = window.scrollY > 300;
-      setShowBackToTop(shouldShow);
-    };
-
-    // Initial check
-    handleScroll();
-
-    // Add scroll listener
-    window.addEventListener("scroll", handleScroll, { passive: true });
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  const scrollToTop = () => {
-    // Find the home section and scroll to it
-    const homeSection = document.getElementById("home");
-    if (homeSection) {
-      homeSection.scrollIntoView({ behavior: "smooth" });
-    }
-  };
 
   const handleNavClick = (e) => {
     e.preventDefault();
@@ -55,118 +28,36 @@ function App() {
     }
   };
 
-  const fadeInUp = {
-    hidden: { opacity: 0, y: 60 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
   return (
     <div className="relative">
       <NavBar onNavClick={handleNavClick} isAuthenticated={isAuthenticated} />
       <main className="pt-16">
-        <motion.div
-          id="home"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        <SectionWrapper id="home">
           <Landing />
-        </motion.div>
-        <motion.div
-          id="about"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        </SectionWrapper>
+        <SectionWrapper id="about">
           <AboutMe />
-        </motion.div>
+        </SectionWrapper>
         {isAuthenticated && (
-          <motion.div
-            id="experience"
-            className="min-h-screen"
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, margin: "-100px" }}
-            variants={fadeInUp}
-          >
+          <SectionWrapper id="experience">
             <Experience />
-          </motion.div>
+          </SectionWrapper>
         )}
-        <motion.div
-          id="skills"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        <SectionWrapper id="skills">
           <LanguageSkills />
-        </motion.div>
-        <motion.div
-          id="github"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        </SectionWrapper>
+        <SectionWrapper id="github">
           <GitHubStats />
-        </motion.div>
-        <motion.div
-          id="leetcode"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        </SectionWrapper>
+        <SectionWrapper id="leetcode">
           <LeetCodeStats />
-        </motion.div>
-        <motion.div
-          id="contact"
-          className="min-h-screen"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={fadeInUp}
-        >
+        </SectionWrapper>
+        <SectionWrapper id="contact">
           <Contact />
-        </motion.div>
+        </SectionWrapper>
       </main>
 
-      <button
-        onClick={scrollToTop}
-        className={`fixed bottom-8 right-8 z-[100] transition-all duration-300 ${
-          showBackToTop ? "opacity-100" : "opacity-0 pointer-events-none"
-        } w-[50px] h-[50px] rounded-full bg-base-300 border-2 border-primary/20 font-semibold flex items-center justify-center shadow-lg cursor-pointer overflow-hidden hover:w-[140px] hover:rounded-[50px] group`}
-        aria-label="Back to top"
-      >
-        <div className="relative w-full h-full flex items-center justify-center">
-          <svg
-            className="w-3 transition-transform duration-300 group-hover:translate-y-[-200%]"
-            viewBox="0 0 384 512"
-          >
-            <path
-              d="M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
-              className="fill-base-content"
-            />
-          </svg>
-          <span className="absolute text-base-content text-[0px] opacity-0 transition-all duration-300 group-hover:text-[13px] group-hover:opacity-100">
-            Back to Top
-          </span>
-        </div>
-      </button>
+      <BackToTopButton />
     </div>
   );
 }

--- a/src/components/AboutMe.jsx
+++ b/src/components/AboutMe.jsx
@@ -1,45 +1,14 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { containerVariants, itemVariants } from "../lib/animations";
+import SectionHeader from "./SectionHeader";
 
 const AboutMe = () => {
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
   return (
     <section className="min-h-screen py-16 bg-base-300 flex items-center">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              About Me
-            </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-primary to-secondary mx-auto rounded-full"></div>
-          </motion.div>
+          <SectionHeader title="About Me" />
 
           <motion.div
             className="prose prose-lg max-w-none mx-auto"

--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+
+function BackToTopButton() {
+  const [showBackToTop, setShowBackToTop] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const shouldShow = window.scrollY > 300;
+      setShowBackToTop(shouldShow);
+    };
+
+    handleScroll();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    const homeSection = document.getElementById("home");
+    if (homeSection) {
+      homeSection.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`fixed bottom-8 right-8 z-[100] transition-all duration-300 ${
+        showBackToTop ? "opacity-100" : "opacity-0 pointer-events-none"
+      } w-[50px] h-[50px] rounded-full bg-base-300 border-2 border-primary/20 font-semibold flex items-center justify-center shadow-lg cursor-pointer overflow-hidden hover:w-[140px] hover:rounded-[50px] group`}
+      aria-label="Back to top"
+    >
+      <div className="relative w-full h-full flex items-center justify-center">
+        <svg
+          className="w-3 transition-transform duration-300 group-hover:translate-y-[-200%]"
+          viewBox="0 0 384 512"
+        >
+          <path
+            d="M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
+            className="fill-base-content"
+          />
+        </svg>
+        <span className="absolute text-base-content text-[0px] opacity-0 transition-all duration-300 group-hover:text-[13px] group-hover:opacity-100">
+          Back to Top
+        </span>
+      </div>
+    </button>
+  );
+}
+
+export default BackToTopButton;

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,51 +1,15 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { containerVariants, itemVariants } from "../lib/animations";
+import { contactInfo } from "../data/siteData";
+import SectionHeader from "./SectionHeader";
 
 const Contact = () => {
-  const contactInfo = {
-    phone: "+1 (551) 358-3376",
-    email: "nikkyjsoriano@gmail.com",
-    location: "East Brunswick, NJ",
-  };
-
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
   return (
     <section className="min-h-screen py-8 bg-base-200 flex items-center">
       <div className="container mx-auto px-4 py-8 sm:py-16">
         <div className="max-w-2xl mx-auto">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              Contact Me
-            </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-primary to-secondary mx-auto rounded-full"></div>
-          </motion.div>
+          <SectionHeader title="Contact Me" textSize="text-4xl" />
 
           <motion.div
             className="grid grid-cols-1 md:grid-cols-3 gap-6"

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,69 +1,15 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { containerVariants, itemVariants } from "../lib/animations";
+import { experiences } from "../data/siteData";
+import SectionHeader from "./SectionHeader";
 
 const Experience = () => {
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
-  const experiences = [
-    {
-      title: "Job Title",
-      company: "Company Name",
-      period: "Start Date – End Date",
-      description:
-        "Placeholder description of role and responsibilities. Replace with actual experience details.",
-    },
-    {
-      title: "Job Title",
-      company: "Company Name",
-      period: "Start Date – End Date",
-      description:
-        "Placeholder description of role and responsibilities. Replace with actual experience details.",
-    },
-    {
-      title: "Job Title",
-      company: "Company Name",
-      period: "Start Date – End Date",
-      description:
-        "Placeholder description of role and responsibilities. Replace with actual experience details.",
-    },
-  ];
-
   return (
     <section className="min-h-screen py-16 bg-base-200 flex items-center">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              Experience
-            </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-primary to-secondary mx-auto rounded-full"></div>
-          </motion.div>
+          <SectionHeader title="Experience" />
 
           <motion.div
             className="space-y-8"

--- a/src/components/GitHubStats.jsx
+++ b/src/components/GitHubStats.jsx
@@ -1,37 +1,15 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { itemVariants } from "../lib/animations";
+import { githubUsername } from "../data/siteData";
+import SectionHeader from "./SectionHeader";
 
 const GitHubStats = () => {
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
-  const username = "nikkyjsoriano";
-
   return (
     <section className="min-h-screen py-16 bg-base-200 flex items-center">
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              Coding Activity
-            </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-primary to-secondary mx-auto rounded-full"></div>
-          </motion.div>
+          <SectionHeader title="Coding Activity" />
 
           <motion.div
             initial="hidden"
@@ -45,7 +23,7 @@ const GitHubStats = () => {
                 <h2 className="card-title text-2xl mb-4 text-primary text-center mx-auto">GitHub Contributions</h2>
                 <div className="rounded-lg overflow-hidden">
                   <img
-                    src={`https://ghchart.rshah.org/3abff8/${username}`}
+                    src={`https://ghchart.rshah.org/3abff8/${githubUsername}`}
                     alt="GitHub Contribution Calendar"
                     className="w-full"
                     style={{ imageRendering: 'pixelated' }}

--- a/src/components/LanguageSkills.jsx
+++ b/src/components/LanguageSkills.jsx
@@ -1,69 +1,8 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { languages, tools } from "../data/siteData";
 
 const LanguageSkills = () => {
-  const languages = [
-    {
-      name: "Vue",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg",
-    },
-    {
-      name: "React",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg",
-    },
-    {
-      name: "HTML",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg",
-    },
-    {
-      name: "JavaScript",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg",
-    },
-    {
-      name: "Spring Boot",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/spring/spring-original.svg",
-    },
-    {
-      name: "FastAPI",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/fastapi/fastapi-original.svg",
-    },
-    {
-      name: "Java",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg",
-    },
-    {
-      name: "Python",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg",
-    },
-    {
-      name: "Grafana",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/grafana/grafana-original.svg",
-    },
-    {
-      name: "InfluxDB",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/influxdb/influxdb-original.svg",
-    },
-  ];
-
-  const tools = [
-    {
-      name: "Git",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg",
-    },
-    {
-      name: "Docker",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg",
-    },
-    {
-      name: "Kubernetes",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kubernetes/kubernetes-plain.svg",
-    },
-    {
-      name: "Terraform",
-      logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/terraform/terraform-original.svg",
-    },
-  ];
-
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {

--- a/src/components/LeetCodeStats.jsx
+++ b/src/components/LeetCodeStats.jsx
@@ -1,37 +1,15 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { itemVariants } from "../lib/animations";
+import { leetcodeUsername } from "../data/siteData";
+import SectionHeader from "./SectionHeader";
 
 const LeetCodeStats = () => {
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.6,
-        ease: "easeOut",
-      },
-    },
-  };
-
-  const username = "Nikky0510";
-
   return (
     <section className="min-h-screen py-16 bg-base-300 flex items-center">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              Problem Solving
-            </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-primary to-secondary mx-auto rounded-full"></div>
-          </motion.div>
+          <SectionHeader title="Problem Solving" />
 
           <motion.div
             initial="hidden"
@@ -45,7 +23,7 @@ const LeetCodeStats = () => {
                 <h2 className="card-title text-2xl mb-4 text-primary text-center mx-auto">LeetCode Stats</h2>
                 <div className="rounded-lg overflow-hidden">
                   <img
-                    src={`https://leetcard.jacoblin.cool/${username}?theme=dark&font=Baloo%202&ext=contest`}
+                    src={`https://leetcard.jacoblin.cool/${leetcodeUsername}?theme=dark&font=Baloo%202&ext=contest`}
                     alt="LeetCode Stats"
                     className="w-full"
                   />

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { navItems } from "../data/navItems";
 
 function NavBar({ onNavClick, isAuthenticated }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -11,6 +12,10 @@ function NavBar({ onNavClick, isAuthenticated }) {
     onNavClick(e);
     setIsMenuOpen(false);
   };
+
+  const visibleItems = navItems.filter(
+    (item) => !item.authRequired || isAuthenticated
+  );
 
   return (
     <div className="navbar bg-base-100 shadow-sm w-full fixed top-0 left-0 right-0 z-50">
@@ -25,43 +30,13 @@ function NavBar({ onNavClick, isAuthenticated }) {
       </div>
       <div className="flex-none hidden lg:flex">
         <ul className="menu menu-horizontal px-1 text-xl text-bold">
-          <li>
-            <a href="#home" onClick={handleNavItemClick}>
-              Home
-            </a>
-          </li>
-          <li>
-            <a href="#about" onClick={handleNavItemClick}>
-              About
-            </a>
-          </li>
-          {isAuthenticated && (
-            <li>
-              <a href="#experience" onClick={handleNavItemClick}>
-                Experience
+          {visibleItems.map((item) => (
+            <li key={item.href}>
+              <a href={item.href} onClick={handleNavItemClick}>
+                {item.label}
               </a>
             </li>
-          )}
-          <li>
-            <a href="#skills" onClick={handleNavItemClick}>
-              Skills
-            </a>
-          </li>
-          <li>
-            <a href="#github" onClick={handleNavItemClick}>
-              GitHub
-            </a>
-          </li>
-          <li>
-            <a href="#leetcode" onClick={handleNavItemClick}>
-              LeetCode
-            </a>
-          </li>
-          <li>
-            <a href="#contact" onClick={handleNavItemClick}>
-              Contact
-            </a>
-          </li>
+          ))}
         </ul>
       </div>
       <div className="flex-none lg:hidden">
@@ -92,71 +67,17 @@ function NavBar({ onNavClick, isAuthenticated }) {
           }`}
         >
           <ul className="menu menu-lg p-2">
-            <li>
-              <a
-                href="#home"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                Home
-              </a>
-            </li>
-            <li>
-              <a
-                href="#about"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                About
-              </a>
-            </li>
-            {isAuthenticated && (
-              <li>
+            {visibleItems.map((item) => (
+              <li key={item.href}>
                 <a
-                  href="#experience"
+                  href={item.href}
                   onClick={handleNavItemClick}
                   className="text-base hover:bg-base-200"
                 >
-                  Experience
+                  {item.label}
                 </a>
               </li>
-            )}
-            <li>
-              <a
-                href="#skills"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                Skills
-              </a>
-            </li>
-            <li>
-              <a
-                href="#github"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a
-                href="#leetcode"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                LeetCode
-              </a>
-            </li>
-            <li>
-              <a
-                href="#contact"
-                onClick={handleNavItemClick}
-                className="text-base hover:bg-base-200"
-              >
-                Contact
-              </a>
-            </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/src/components/SectionHeader.jsx
+++ b/src/components/SectionHeader.jsx
@@ -1,0 +1,20 @@
+import { motion } from "framer-motion";
+
+function SectionHeader({ title, gradient = "from-primary to-secondary", textSize = "text-5xl" }) {
+  return (
+    <motion.div
+      className="text-center mb-12"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-100px" }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+    >
+      <h1 className={`${textSize} font-bold mb-4 bg-gradient-to-r ${gradient} bg-clip-text text-transparent`}>
+        {title}
+      </h1>
+      <div className={`w-24 h-1 bg-gradient-to-r ${gradient} mx-auto rounded-full`}></div>
+    </motion.div>
+  );
+}
+
+export default SectionHeader;

--- a/src/components/SectionWrapper.jsx
+++ b/src/components/SectionWrapper.jsx
@@ -1,0 +1,19 @@
+import { motion } from "framer-motion";
+import { fadeInUp } from "../lib/animations";
+
+function SectionWrapper({ id, children }) {
+  return (
+    <motion.div
+      id={id}
+      className="min-h-screen"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-100px" }}
+      variants={fadeInUp}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export default SectionWrapper;

--- a/src/data/navItems.js
+++ b/src/data/navItems.js
@@ -1,0 +1,9 @@
+export const navItems = [
+  { href: "#home", label: "Home" },
+  { href: "#about", label: "About" },
+  { href: "#experience", label: "Experience", authRequired: true },
+  { href: "#skills", label: "Skills" },
+  { href: "#github", label: "GitHub" },
+  { href: "#leetcode", label: "LeetCode" },
+  { href: "#contact", label: "Contact" },
+];

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -1,0 +1,95 @@
+export const languages = [
+  {
+    name: "Vue",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg",
+  },
+  {
+    name: "React",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg",
+  },
+  {
+    name: "HTML",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg",
+  },
+  {
+    name: "JavaScript",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg",
+  },
+  {
+    name: "Spring Boot",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/spring/spring-original.svg",
+  },
+  {
+    name: "FastAPI",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/fastapi/fastapi-original.svg",
+  },
+  {
+    name: "Java",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg",
+  },
+  {
+    name: "Python",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg",
+  },
+  {
+    name: "Grafana",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/grafana/grafana-original.svg",
+  },
+  {
+    name: "InfluxDB",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/influxdb/influxdb-original.svg",
+  },
+];
+
+export const tools = [
+  {
+    name: "Git",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg",
+  },
+  {
+    name: "Docker",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg",
+  },
+  {
+    name: "Kubernetes",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kubernetes/kubernetes-plain.svg",
+  },
+  {
+    name: "Terraform",
+    logo: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/terraform/terraform-original.svg",
+  },
+];
+
+export const experiences = [
+  {
+    title: "Job Title",
+    company: "Company Name",
+    period: "Start Date – End Date",
+    description:
+      "Placeholder description of role and responsibilities. Replace with actual experience details.",
+  },
+  {
+    title: "Job Title",
+    company: "Company Name",
+    period: "Start Date – End Date",
+    description:
+      "Placeholder description of role and responsibilities. Replace with actual experience details.",
+  },
+  {
+    title: "Job Title",
+    company: "Company Name",
+    period: "Start Date – End Date",
+    description:
+      "Placeholder description of role and responsibilities. Replace with actual experience details.",
+  },
+];
+
+export const contactInfo = {
+  phone: "+1 (551) 358-3376",
+  email: "nikkyjsoriano@gmail.com",
+  location: "East Brunswick, NJ",
+};
+
+export const githubUsername = "nikkyjsoriano";
+
+export const leetcodeUsername = "Nikky0510";

--- a/src/lib/animations.js
+++ b/src/lib/animations.js
@@ -1,0 +1,33 @@
+export const fadeInUp = {
+  hidden: { opacity: 0, y: 60 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: "easeOut",
+    },
+  },
+};
+
+export const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.2,
+    },
+  },
+};
+
+export const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: "easeOut",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Extract shared Framer Motion animation variants, site data, and nav items into dedicated modules (`src/lib/`, `src/data/`)
- Create reusable `SectionWrapper`, `SectionHeader`, and `BackToTopButton` components to eliminate duplicated markup
- Simplify `App.jsx` and `NavBar.jsx` by consuming shared modules — net reduction of 184 lines

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] `npm run lint` passes with no errors
- [ ] All sections render identically to before
- [ ] Scroll animations still trigger once per section
- [ ] Nav links work (desktop + mobile drawer)
- [ ] Back-to-top button appears on scroll and works
- [ ] Experience section hidden by default, visible with `?password=password123`