### PR TITLE
Refactor portfolio into shared modules

### DIFF
--- a/src/components/AboutMe.jsx
+++ b/src/components/AboutMe.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { containerVariants, itemVariants } from "../lib/animations";
+import { aboutMe } from "../data/siteData";
 import SectionHeader from "./SectionHeader";
 
 const AboutMe = () => {
@@ -17,54 +18,29 @@ const AboutMe = () => {
             whileInView="visible"
             viewport={{ once: true, margin: "-100px" }}
           >
-            <motion.p className="mb-4 text-lg" variants={itemVariants}>
-              Hi! 👋 I'm Nikky, a{" "}
-              <span className="text-primary font-semibold">
-                full-stack developer
-              </span>{" "}
-              focused on building modern web applications and cloud solutions. I
-              enjoy creating impactful software that solves real-world problems.
-            </motion.p>
-            <motion.p className="mb-4 text-lg" variants={itemVariants}>
-              On the frontend, I work with{" "}
-              <span className="text-secondary font-semibold">React</span>,{" "}
-              <span className="text-secondary font-semibold">Vue</span>,{" "}
-              <span className="text-secondary font-semibold">HTML</span>, and{" "}
-              <span className="text-secondary font-semibold">JavaScript</span>{" "}
-              to build responsive and intuitive interfaces. For the backend, I
-              use
-              <span className="text-accent font-semibold">
-                {" "}
-                Spring Boot
-              </span>,{" "}
-              <span className="text-accent font-semibold">FastAPI</span>, and{" "}
-              <span className="text-accent font-semibold">Python</span> to
-              develop scalable applications.
-            </motion.p>
-            <motion.p className="mb-4 text-lg" variants={itemVariants}>
-              I also specialize in{" "}
-              <span className="text-primary font-semibold">
-                data engineering
-              </span>
-              , where I build data pipelines, work with time-series databases
-              like{" "}
-              <span className="text-secondary font-semibold">InfluxDB</span>,
-              and create visualizations using{" "}
-              <span className="text-secondary font-semibold">Grafana</span>. My
-              experience includes data processing,{" "}
-              <span className="text-accent font-semibold">ETL workflows</span>,
-              and{" "}
-              <span className="text-accent font-semibold">
-                real-time analytics
-              </span>
-              .
-            </motion.p>
+            {aboutMe.paragraphs.map((segments, i) => (
+              <motion.p
+                key={i}
+                className="mb-4 text-lg"
+                variants={itemVariants}
+              >
+                {segments.map((segment, j) =>
+                  segment.color ? (
+                    <span key={j} className={`${segment.color} font-semibold`}>
+                      {segment.text}
+                    </span>
+                  ) : (
+                    <React.Fragment key={j}>{segment.text}</React.Fragment>
+                  )
+                )}
+              </motion.p>
+            ))}
             <motion.p className="text-lg" variants={itemVariants}>
               I'm always looking to learn new technologies and take on
               interesting projects. You can find me on various platforms below,
               and if you'd like to see my resume{" "}
               <a
-                href="https://drive.google.com/uc?export=download&id=1-jxTcrXF17w7_XAPt122e_uX9aJdvCB0"
+                href={aboutMe.resumeLink}
                 className="text-primary hover:text-primary-focus font-medium transition-colors duration-300"
               >
                 Click Here

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -90,6 +90,55 @@ export const contactInfo = {
   location: "East Brunswick, NJ",
 };
 
+export const aboutMe = {
+  resumeLink:
+    "https://drive.google.com/uc?export=download&id=1-jxTcrXF17w7_XAPt122e_uX9aJdvCB0",
+  paragraphs: [
+    [
+      { text: "Hi! 👋 I'm Nikky, a " },
+      { text: "full-stack developer", color: "text-primary" },
+      {
+        text: " focused on building modern web applications and cloud solutions. I enjoy creating impactful software that solves real-world problems.",
+      },
+    ],
+    [
+      { text: "On the frontend, I work with " },
+      { text: "React", color: "text-secondary" },
+      { text: ", " },
+      { text: "Vue", color: "text-secondary" },
+      { text: ", " },
+      { text: "HTML", color: "text-secondary" },
+      { text: ", and " },
+      { text: "JavaScript", color: "text-secondary" },
+      {
+        text: " to build responsive and intuitive interfaces. For the backend, I use ",
+      },
+      { text: "Spring Boot", color: "text-accent" },
+      { text: ", " },
+      { text: "FastAPI", color: "text-accent" },
+      { text: ", and " },
+      { text: "Python", color: "text-accent" },
+      { text: " to develop scalable applications." },
+    ],
+    [
+      { text: "I also specialize in " },
+      { text: "data engineering", color: "text-primary" },
+      {
+        text: ", where I build data pipelines, work with time-series databases like ",
+      },
+      { text: "InfluxDB", color: "text-secondary" },
+      { text: ", and create visualizations using " },
+      { text: "Grafana", color: "text-secondary" },
+      { text: ". My experience includes data processing, " },
+      { text: "ETL workflows", color: "text-accent" },
+      { text: ", and " },
+      { text: "real-time analytics", color: "text-accent" },
+      { text: "." },
+    ],
+  ],
+};
+
+
 export const githubUsername = "nikkyjsoriano";
 
 export const leetcodeUsername = "Nikky0510";


### PR DESCRIPTION
## Summary
- Extract shared Framer Motion variants, site data, and nav items into dedicated modules (`src/lib/`, `src/data/`)
- Create reusable `SectionWrapper`, `SectionHeader`, and `BackToTopButton` components
- Move About Me content into data-driven segment arrays in `siteData.js`
- Simplify `App.jsx` and `NavBar.jsx` by consuming shared modules
- Net reduction of 160 lines across 15 files

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] `npm run lint` passes with no errors
- [ ] All sections render identically to before
- [ ] Scroll animations still trigger once per section
- [ ] Nav links work (desktop + mobile drawer)
- [ ] Back-to-top button appears on scroll and works
- [ ] Experience section hidden by default, visible with `?password=password123`